### PR TITLE
Remove response.request._ca from errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,9 @@ module.exports = function(opts) {
   var serializers = _.assign({
     err: function(err) {
       var isLikelyErrorType = err.name && err.message;
+      if (err.response && err.response.request) {
+        delete err.response.request._ca;
+      }
       return isLikelyErrorType ? Errio.toObject(err, {stack: opts.stackTrace}) : err;
     },
     req: function(req) {


### PR DESCRIPTION
CA string is too long to include in logs, and isn't of any value so zap it.
